### PR TITLE
Use reserved values as new CVs 74 - 81 for output pin config (e.g., r…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,12 @@ Signal7_Green_Red.txt
 Signal8_Green_Red.txt
 Signal7_DCC_Aspects_2_3.txt
 Signal0_DCC_Aspects_0_1_UserDefinedSignal0.txt
+Signal0_ADC_Green_Red_StepSize_1.txt
+Signal0_ADC_Green_Red_StepSize_2.txt
+Signal0_ADC_Green_Red_StepSize_m1.txt
+Signal1_ADC_Green_Red_StepSize_1.txt
+Signal1_ADC_Green_Red_StepSize_2.txt
+Signal1_ADC_Green_Red_StepSize_m1.txt
+Signal7_ADC_Green_Red_StepSize_1.txt
+Signal7_ADC_Green_Red_StepSize_2.txt
+Signal7_ADC_Green_Red_StepSize_m1.txt

--- a/Src/Prj/App/Signal/Cal/CalM.cpp
+++ b/Src/Prj/App/Signal/Cal/CalM.cpp
@@ -33,7 +33,8 @@ namespace cal
      * @note Adjust unit test Ut_Signal/Test.cpp if this definition changes.
      */
     #define CAL_BUILT_IN_SIGNAL_OUTPUTS     \
-        {                                   \
+        {   /* Ausfahrsignal */             \
+            /* red red green yellow white */\
             5,                              \
             0b00011000, 0b00000000,         \
             0b00000100, 0b00000000,         \
@@ -44,15 +45,29 @@ namespace cal
             0b00011111, 0b00000000,         \
             0b00011111, 0b00000000,         \
             10, 10,                         \
+            /* Blocksignal */               \
+            /* red green */                 \
             2,                              \
+            0b00000010, 0b00000000,         \
             0b00000001, 0b00000000,         \
+            0b00000011, 0b00000000,         \
+            0b00000011, 0b00000000,         \
+            0b00000011, 0b00000000,         \
+            0b00000011, 0b00000000,         \
+            0b00000011, 0b00000000,         \
+            0b00000011, 0b00000000,         \
+            10, 10,                         \
+            /* Einfahrsignal */             \
+            /* red red green yellow */      \
+            4,                              \
+            0b00001100, 0b00000000,         \
             0b00000010, 0b00000000,         \
             0b00000011, 0b00000000,         \
-            0b00000011, 0b00000000,         \
-            0b00000011, 0b00000000,         \
-            0b00000011, 0b00000000,         \
-            0b00000011, 0b00000000,         \
-            0b00000011, 0b00000000,         \
+            0b00001111, 0b00000000,         \
+            0b00001111, 0b00000000,         \
+            0b00001111, 0b00000000,         \
+            0b00001111, 0b00000000,         \
+            0b00001111, 0b00000000,         \
             10, 10                          \
         }
 
@@ -125,13 +140,17 @@ namespace cal
             }
 
             // output pins
-            const struct signal::target output = get_first_output(sig_idx);
+            struct signal::target output = get_first_output(sig_idx);
+            const sint8 pin_inc = is_output_pin_order_inverse(sig_idx) ? 
+                                 -get_output_pin_step_size(sig_idx) : 
+                                  get_output_pin_step_size(sig_idx);
             if (output.type == signal::target::kOnboard)
             {
                 const uint8 num_outputs = get_number_of_outputs(get_signal_id(sig_idx));
-                for (uint8_least pin = output.pin; pin < output.pin + num_outputs; pin++)
+                for (uint8_least pin_idx = 0; pin_idx < num_outputs; pin_idx++)
                 {
-                    gpio_cfg.pin_modes[pin] = OUTPUT;
+                    gpio_cfg.pin_modes[output.pin] = OUTPUT;
+                    output.pin = static_cast<uint8>(static_cast<sint8>(output.pin) + pin_inc);
                 }
             }
         }

--- a/Src/Prj/App/Signal/Cal/CalM.h
+++ b/Src/Prj/App/Signal/Cal/CalM.h
@@ -136,14 +136,20 @@ namespace cal
             if (is_cv_id_valid(cv_id))
             {
                 eeprom_data_buffer[cv_id] = val;
-                if (cv_id >= cv::kSignalInputBase &&
-                    cv_id < cv::kSignalInputBase + cfg::kNrSignals)
+                if ((cv_id >= cv::kSignalInputBase) &&
+                    (cv_id < cv::kSignalInputBase + cfg::kNrSignals))
                 {
                     // reconfigure pins if input CV changed
                     configure_pins();
                 }
-                else if (cv_id >= cv::kSignalFirstOutputBase &&
-                    cv_id < cv::kSignalFirstOutputBase + cfg::kNrSignals)
+                else if ((cv_id >= cv::kSignalFirstOutputBase) &&
+                         (cv_id < cv::kSignalFirstOutputBase + cfg::kNrSignals))
+                {
+                    // reconfigure pins if input CV changed
+                    configure_pins();
+                }
+                else if ((cv_id >= cv::kSignalOutputConfigBase) &&
+                         (cv_id < cv::kSignalOutputConfigBase + cfg::kNrSignals))
                 {
                     // reconfigure pins if input CV changed
                     configure_pins();
@@ -341,6 +347,31 @@ namespace cal
         {
             struct signal::target output = get_cv(cal::cv::kSignalFirstOutputBase + signal_idx);
             return output;
+        }
+        /**
+         * @brief Return true if the output pin order is inverse
+         * @param signal_idx Signal index (0 ... cfg::kNrSignals-1)
+         * @return true Output pin order is inverse
+         * @return false Output pin order is normal
+         */
+        inline bool is_output_pin_order_inverse(uint8 signal_idx)
+        {
+            uint8 output_config = get_cv(cal::cv::kSignalOutputConfigBase + signal_idx);
+            // A 1 in bit kOutputPinOrder means inverse order
+            return (output_config & cal::constants::bitmask::kOutpoutPinOrder) != 0U;
+        }
+        /**
+         * @brief Returns the output pin step size, e.g. 13, 14, 15, 16 (step size 1) or 
+         *        13, 15, 17, 19 (step size 2). Or 13, 12, 11, 10 (step size 1, inverse order) or
+         *        13, 11, 9, 7 (step size 2, inverse order)
+         * @param signal_idx Signal index (0 ... cfg::kNrSignals-1)
+         * @return 1 or 2 Output pin step size
+         */
+        inline uint8 get_output_pin_step_size(uint8 signal_idx)
+        {
+            uint8 output_config = get_cv(cal::cv::kSignalOutputConfigBase + signal_idx);
+            // A 1 in bit kOutpoutPinStepSize means step size of 2, else step size of 1
+            return ((output_config & cal::constants::bitmask::kOutpoutPinStepSize) != 0U) ? 2 : 1;
         }
         /** @} */
 

--- a/Src/Prj/App/Signal/Cal/CalM_Types_Prj.h
+++ b/Src/Prj/App/Signal/Cal/CalM_Types_Prj.h
@@ -52,6 +52,7 @@ namespace cal
         constexpr uint16 kSignalFirstOutputBase = 50;
         constexpr uint16 kSignalInputBase = 58;
         constexpr uint16 kSignalInputClassifierTypeBase = 66;
+        constexpr uint16 kSignalOutputConfigBase = 74;
         constexpr uint16 kClassifierBase = 112; // Number of classifiers: cfg::kNrClassifiers
                                                 // with number of classes: cfg::kNrClassifierClasses
         constexpr uint16 kUserDefinedSignalBase = 134;
@@ -86,6 +87,8 @@ namespace cal
             constexpr uint8 kAdcPin = 0b00111111;          /**< ADC pin mask */
             constexpr uint8 kClassifierType = 0b00000011;  /**< Classifier type mask */
             constexpr uint8 kNumberOfOutputs = 0b00001111;  /**< Number of outputs mask */
+            constexpr uint8 kOutpoutPinOrder = 0b00000001;  /**< Output pin order mask */
+            constexpr uint8 kOutpoutPinStepSize = 0b00000010;  /**< Output pin step size mask*/
         }
         namespace bitshift
         {
@@ -95,6 +98,8 @@ namespace cal
             constexpr uint8 kAdcPin = 0;          /**< ADC pin shift */
             constexpr uint8 kClassifierType = 0;  /**< Classifier type shift */
             constexpr uint8 kNumberOfOutputs = 0;  /**< Number of outputs shift */
+            constexpr uint8 kOutpoutPinOrder = 0;  /**< Output pin order shift */
+            constexpr uint8 kOutpoutPinStepSize = 1;  /**< Output pin step size shift */
         }
         /** @brief Create a CV for signal input value. */
         constexpr uint8 make_signal_input(uint8 input_type, uint8 input_pin) noexcept

--- a/Src/Prj/App/Signal/Cfg_Prj.h
+++ b/Src/Prj/App/Signal/Cfg_Prj.h
@@ -30,7 +30,7 @@ namespace cfg
     /**
      * @brief Manufacturer version ID (for CV 7)
      */
-    constexpr uint8 kManufacturerVersionID = 0x01;  /* v0.1 */
+    constexpr uint8 kManufacturerVersionID = 0x20;  /* v2.0 */
     /** 
      * @brief Maximum number of signals 
      */
@@ -51,7 +51,7 @@ namespace cfg
 
     constexpr uint8 kNrUserDefinedClassifierTypes = 2; ///< Number of user defineable classifier types (in EEPROM)
     constexpr uint8 kNrUserDefinedSignals = 2;         ///< Number of user defineable signal IDs (in EEPROM)
-    constexpr uint8 kNrBuiltInSignals = 2;             ///< Number of built in signal IDs (in ROM)
+    constexpr uint8 kNrBuiltInSignals = 3;             ///< Number of built in signal IDs (in ROM)
 
     constexpr int kNrOnboardTargets = 54;  ///< We support up to 54 onboard LED targets (some of them with PWM))
     constexpr int kNrExternalTargets = 32; ///< We support up to 32 external outputs (such as 4 shift registers with 8 bit each)

--- a/Src/Prj/App/Signal/Rte/Rte_Cfg_Cod.h
+++ b/Src/Prj/App/Signal/Rte/Rte_Cfg_Cod.h
@@ -97,6 +97,28 @@ namespace rte
         static inline struct signal::target get_first_output(uint8 signal_idx) { return calm.get_first_output(signal_idx); }
 
         /**
+         * @brief Return true if the output pin order is inverse, e.g. pins 13, 12, 11, 10 instead 
+         *        of 13, 14, 15, 16
+         * @param signal_idx Signal index (0 ... cfg::kNrSignals-1)
+         * @return true Output pin order is inverse
+         * @return false Output pin order is normal
+         */
+        static inline bool is_output_pin_order_inverse(uint8 signal_idx) { return calm.is_output_pin_order_inverse(signal_idx); }
+
+        /**
+         * @brief Returns the output pin step size (1 or 2).
+         * 
+         * Step size 1, increasing order means, e.g., 13, 14, 15, 16
+         * Step size 2, increasing order means, e.g., 13, 15, 17, 19
+         * Step size 1, decreasing (inverse) order means, e.g., 13, 12, 11, 10
+         * Step size 2, decreasing (inverse) order means, e.g., 13, 11, 9, 7
+         * 
+         * @param signal_idx Signal index (0 ... cfg::kNrSignals-1)
+         * @return 1 or 2 Output pin step size
+         */
+        static inline uint8 get_output_pin_step_size(uint8 signal_idx) { return calm.get_output_pin_step_size(signal_idx); }
+
+        /**
          * @brief Check if the given pin is configured as an output pin
          * 
          * @param pin Pin number to check

--- a/Src/Prj/App/Signal/Signal_cfg.h
+++ b/Src/Prj/App/Signal/Signal_cfg.h
@@ -2,7 +2,8 @@
 /**
  * @file App/Signal/Signal_cfg.h
  *
- * @brief Configuration header file for Signal class
+ * @brief Configuration header file for Signal class. Implements inline functions to access
+ *        interfaces for calibration and RTE.
  *
  * @note This file must be included in Signal.cpp only
  * @note All functions in this file are defined as inline to allow compile-time optimization
@@ -78,6 +79,26 @@ namespace signal_cal
     {
         return rte::sig::get_first_output(signal_idx);
     }
+    /**
+     * @brief Return true if the output pin order is inverse, e.g. pins 13, 12, 11, 10 instead 
+     *        of 13, 14, 15, 16
+     * @param signal_idx Signal index (0 ... cfg::kNrSignals-1)
+     * @return true Output pin order is inverse
+     * @return false Output pin order is normal
+     */
+    static inline bool is_output_pin_order_inverse(uint8 signal_idx) { return rte::sig::is_output_pin_order_inverse(signal_idx); }
+    /**
+     * @brief Returns the output pin step size (1 or 2).
+     * 
+     * Step size 1, increasing order means, e.g., 13, 14, 15, 16
+     * Step size 2, increasing order means, e.g., 13, 15, 17, 19
+     * Step size 1, decreasing (inverse) order means, e.g., 13, 12, 11, 10
+     * Step size 2, decreasing (inverse) order means, e.g., 13, 11, 9, 7
+     * 
+     * @param signal_idx Signal index (0 ... cfg::kNrSignals-1)
+     * @return 1 or 2 Output pin step size
+     */
+    static inline uint8 get_output_pin_step_size(uint8 signal_idx) { return rte::sig::get_output_pin_step_size(signal_idx); }
 } // namespace signal_cal
 
 namespace signal_rte


### PR DESCRIPTION
This pull request introduces enhancements to the signal output configuration, enabling support for customizable output pin order and step size per signal. It also adds a new built-in signal type, updates configuration constants, and refactors code to utilize the new configuration options throughout the codebase.

**Signal Output Configuration Enhancements:**

* Added support for configuring output pin order (normal/inverse) and step size (1 or 2) per signal via new calibration variables and bitmasks. This includes new inline functions `is_output_pin_order_inverse` and `get_output_pin_step_size` in `CalM.h`, `Signal_cfg.h`, and corresponding RTE interfaces. [[1]](diffhunk://#diff-807374416f66554aef980787f85b771982975b18979feb7523a4568988be85dbR351-R375) [[2]](diffhunk://#diff-37d883e868beefadf5156ba915267dd905f577511c3c4a2e0daa459a453f76f7R82-R101) [[3]](diffhunk://#diff-5c692fabe678afd9a621803121478cd735834e6209a3f2c9e6b2024f2581549eR99-R120) [[4]](diffhunk://#diff-7042f81a106b9aa2d6cd35b3e1cbe3e33704fe8cd77e7611273069a469b64a46R90-R91) [[5]](diffhunk://#diff-7042f81a106b9aa2d6cd35b3e1cbe3e33704fe8cd77e7611273069a469b64a46R101-R102)
* Refactored signal output handling in `Signal.cpp` and `CalM.cpp` to use the new pin order and step size configuration, ensuring correct pin sequencing for all signals. [[1]](diffhunk://#diff-4c66e5eb0f3436721a0f4c3a16c72629c966b6dd41a88ae71e1f7c56c2df850fR92-R98) [[2]](diffhunk://#diff-4c66e5eb0f3436721a0f4c3a16c72629c966b6dd41a88ae71e1f7c56c2df850fL116-R137) [[3]](diffhunk://#diff-5c686aa7587239664c46be06b9bdbd5f0042c7394e0bab900868f4a4f63d15a8L128-R153)

**Built-in Signals and Configuration Updates:**

* Added a third built-in signal ("Einfahrsignal") to the built-in signals list and updated corresponding configuration constants, such as `kNrBuiltInSignals`. [[1]](diffhunk://#diff-5c686aa7587239664c46be06b9bdbd5f0042c7394e0bab900868f4a4f63d15a8L36-R37) [[2]](diffhunk://#diff-5c686aa7587239664c46be06b9bdbd5f0042c7394e0bab900868f4a4f63d15a8R48-R70) [[3]](diffhunk://#diff-d13c309c238eef1b99c6cfc6ea80ca2b08468e43c80820635ff4bd3ef6a486eaL54-R54)
* Updated the manufacturer version ID to 0x20 (v2.0) to prepare Release v2.0.0.

**Calibration and EEPROM Handling:**

* Introduced a new calibration variable base (`kSignalOutputConfigBase`) for storing output configuration per signal and updated EEPROM write logic to trigger reconfiguration when this value changes. [[1]](diffhunk://#diff-7042f81a106b9aa2d6cd35b3e1cbe3e33704fe8cd77e7611273069a469b64a46R55) [[2]](diffhunk://#diff-807374416f66554aef980787f85b771982975b18979feb7523a4568988be85dbL139-R152)

**Documentation and Comments:**

* Improved and expanded documentation in headers and inline comments to clarify the new configuration options and their usage. [[1]](diffhunk://#diff-37d883e868beefadf5156ba915267dd905f577511c3c4a2e0daa459a453f76f7L5-R6) [[2]](diffhunk://#diff-5c692fabe678afd9a621803121478cd735834e6209a3f2c9e6b2024f2581549eR99-R120)

These changes collectively make the signal handling logic more flexible and extensible, supporting more complex signal configurations and hardware setups.…everse order and step size). Change value of manufacturer Version ID from 0.1 to 2.0. Add a third built in signal Einfahrsignal. Add appropriate unit tests.