### PR TITLE
Add external take over

### DIFF
--- a/Src/Prj/App/Signal/Com/AsciiCom.h
+++ b/Src/Prj/App/Signal/Com/AsciiCom.h
@@ -104,23 +104,11 @@ namespace com
      * setting and getting signal aspects, blinks, targets, input classification,
      * and change-over times, as well as configuring classifiers.
      *
-     * @section Set and get CV's
-     * @brief Commands to set and get a CV. Command to initialize EEPROM.
-     *
-     * | Command | Description | Example Usage |
-     * |---------|-------------|--------------|
-     * | `SET_CV cv_id value` | Set the CV with id `cv_id` to `value value`. | `SET_CV 29 64` |
-     * | `GET_CV cv_id`       | Get the value of the CV with id `cv_id`.     | `GET_CV 29`    |
-     * | `INIT`               | Initialize EEPROM with default values.       | `INIT`         |
-     * 
-     * @section Monitoring
-     * @brief Commands to monitor RTE
-     *
-     * | Command | Description | Example Usage |
-     * |---------|-------------|--------------|
-     * | `MON_LIST` | Print available RTE ports (`ifc-name`) via serial interface. | `MON_LIST` Prints the available interfaces to the terminal. |
-     * | `MON_START cycle-time ifc-name [id-first id-nr]` | Start to print current values of `ifc-name`. Currently, just one RTE port can be printed at one time. Cycle time is `cycle-time` [ms]. `id-first` and `id-nr` are optional and define the span of an array that is to be transmitted [`id-first`, `id-first + id-nr`]. | `MON_START 100 ifc_ad_values`<br>read AD values of the classifiers. |
-     * | `MON_STOP` | Stop to print RTE port. | `MON_STOP` |
+     * For communication, it uses ASCII-formatted telegrams where commands and parameters
+     * are separated by spaces. The class can handle various commands such as `SET_CV`,
+     * `MON_LIST`, `MON_START`, `MON_STOP`, and `INIT`. It generates appropriate responses
+     * based on the processed commands. See the readme.md documentation for telegram descriptions 
+     * and usage examples.
      */
     class AsciiCom : public Observer
     {

--- a/Src/Prj/App/Signal/Doc/Readme.md
+++ b/Src/Prj/App/Signal/Doc/Readme.md
@@ -81,7 +81,7 @@ These commands are used to change the configuration.
 |-------------------|----------------------------------------------|----------------|
 | `SET_CV id value` | Set the CV with id `cv_id` to `value value`. | `SET_CV 29 64` |
 | `GET_CV id`       | Get the value of the CV with id `cv_id`.     | `GET_CV 29`    |
-| `SET_SIGNAL idx id [ONB,EXT] output_pin step_size [ADC,DIG,DCC] input_pin` | Set CVs for signal `idx`<br>`42 + idx`: id<br>`50 + idx`: output type and pin<br>`58 + idx`: input type and pin<br>`74 + idx`: derived from step_size | `SET_SIGNAL 0 1 ONB 6 -1 ADC 54`    |
+| `SET_SIGNAL idx id [ONB,EXT] output_pin step_size [ADC,DIG,DCC] input_pin` | Set CVs for signal `idx`<br>`42 + idx`: id<br>`50 + idx`: output type and pin<br>`58 + idx`: input type and pin<br>`74 + idx`: derived from step_size | `SET_SIGNAL 0 1 ONB 6 -1 ADC 54`<br>Set signal at position `0` to built-in signal `1` (Ausfahrsignal) with onboard output pins `6`, `5`, ..., `2`, and input `ADC` at pin `54` (A0).  |
 | `GET_SIGNAL idx`  | Get values for signal `idx` from CVSs<br>`42 + idx`: id<br>`50 + idx`: output type and pin<br>`58 + idx`: input type and pin<br>`74 + idx`: derived from step_size | `GET_SIGNAL 0` prints the parameters as provided by `SET_SIGNAL`  |
 | `GET_PIN_CONFIG pin` | Print `output`or `input` for `pin`.       | `GET_PIN_CONFIG 10`  |
 | `INIT`            | Initialize EEPROM with default values.       | `INIT`         |
@@ -101,6 +101,32 @@ These commands are used to output internal data structures to the terminal.
 | Command           | Description                                  | Example Usage  |
 |-------------------|----------------------------------------------|----------------|
 | `SET_VERBOSE level` | Enable verbose debug messages up to `level` (0 - 3).       | `SET_VERBOSE 3`      |
+| `ETO_SET_SIGNAL idx aspect [dim_time]` | Enables or disables the ETO signal aspect for the signal at position `idx`.<br>If `aspect` is 0, the ETO signal aspect is disabled.<br>If `aspect` is non-zero, the ETO signal aspect is enabled with the given aspect value.<br>The `dim_time` parameter is optional and sets the dimming time in units of 10 ms.      | `ETO_SET_SIGNAL 0 1 5`<br>Enables external take-over for signal at position `0` with aspect `0b00000001` and dim time 50 ms.<br>`ETO_SET_SIGNAL 0 0`<br>Disables external take-over for signal at position `0`. |
+
+#### Built-in Signals
+
+**Ausfahrsignal (id 1)**
+
+Five (5) outputs:
+  - Red
+  - Red
+  - Green
+  - Yellow
+  - White
+
+**Blocksignal (id 2)**
+
+Two (2) outputs:
+  - Red
+  - Green
+
+**Einfahrsignal (id 3)**
+
+Four (4) outputs:
+  - Red
+  - Red
+  - Green
+  - Yellow
 
 #### List of CVs
 
@@ -136,7 +162,7 @@ Version 1.0
 |39|0b00000001|R+W|1|N/A|N/A|N|N|DCC addressing mode, 0 = ROCO, 1 = RCN-213|
 |40|0b11111111|R|8|0 - 8|0 - 4|Y|Y|Maximum number of signals|
 |41|0b11111111|R|2|2|2|Y|Y|Number of built-in signal-IDs|
-|42|0b11111111|R+W|0|0 - 8||Y|Y|Signal-ID of signal 1 (0 = signal not used, 1 = Ausfahrsignal, 2 = Blocksignal, >=128 user defined signal)|
+|42|0b11111111|R+W|0|0 - 8||Y|Y|Signal-ID of signal 1 (0 = signal not used, 1 ... 127 = built-in signal, >=128 user defined signal)|
 |43|0b11111111|R+W|0|0 - 8||Y|Y|Signal-ID of signal 2|
 |44|0b11111111|R+W|0|0 - 8||Y|Y|Signal-ID of signal 3|
 |45|0b11111111|R+W|0|0 - 8||Y|Y|Signal-ID of signal 4|

--- a/Src/Prj/App/Signal/Rte/Rte_Cfg_Cod.h
+++ b/Src/Prj/App/Signal/Rte/Rte_Cfg_Cod.h
@@ -71,15 +71,35 @@ namespace rte
          */
         static inline bool is_user_defined(uint8 signal_id) noexcept { return calm.is_user_defined(signal_id); }
 
-        /** @brief Get the signal aspect for a user-defined signal ID
+        /** 
+         * @brief Get the signal aspect for the signal id.
          * 
-         * @param signal_id Signal id (user-defined)
+         * @param signal_id Signal id (eSignalNotUsed, eFirstBuiltInSignalId, ..., eFirstUserDefinedSignalID, ...)
          * @param cmd Command index (0 ... cfg::kNrSignalAspects-1)
          * @param aspect Output: signal aspect configuration
          */
         static inline void get_signal_aspect(uint8 signal_id, uint8 cmd, struct signal::signal_aspect& aspect)
         {
             calm.get_signal_aspect(signal_id, cmd, aspect);
+        }
+
+        /** 
+         * @brief Get the signal aspect for the signal.
+         * 
+         * This function supports external take-over functionality.
+         * Use eto_set_signal_aspect_for_idx to set or clear external take-over aspects and dim times.
+         * 
+         * @note The function name differs from CalM::get_signal_aspect to avoid confusion.
+         * CalM::get_signal_aspect uses the Signal ID signal_id as first parameter, this function 
+         * uses signal_idx.
+         * 
+         * @param signal_idx Signal index (0 ... cfg::kNrSignals-1)
+         * @param cmd Command index (0 ... cfg::kNrSignalAspects-1)
+         * @param aspect Output: signal aspect configuration
+         */
+        static inline void get_signal_aspect_for_idx(uint8 signal_idx, uint8 cmd, struct signal::signal_aspect& aspect)
+        {
+            calm.get_signal_aspect_for_idx(signal_idx, cmd, aspect);
         }
 
         /**
@@ -142,6 +162,23 @@ namespace rte
          * @return uint8 Number of outputs for the signal
          */
         static inline uint8 get_number_of_outputs(uint8 signal_id) { return calm.get_number_of_outputs(signal_id); }
+
+        /**
+         * @brief Set the signal aspect for external take-over.
+         * 
+         * @param signal_idx Signal index (0 ... cfg::kNrSignals-1)
+         * @param eto_active true: external take-over active for this signal, false: inactive
+         * @param aspect Signal aspect value, e.g. 0b00001101 for 4 outputs
+         * @param dim_time_10ms Dim time in 10ms units
+         */
+        static inline void eto_set_signal_aspect_for_idx(
+            uint8 signal_idx, 
+            bool eto_active, 
+            uint8 aspect, 
+            uint8 dim_time_10ms) 
+        { 
+            calm.eto_set_signal_aspect_for_idx(signal_idx, eto_active, aspect, dim_time_10ms); 
+        }
     }
 }
 

--- a/Src/Prj/App/Signal/Signal.cpp
+++ b/Src/Prj/App/Signal/Signal.cpp
@@ -42,8 +42,6 @@ namespace signal
         util::intensity16 intensity;
         struct signal::signal_aspect signal_asp;
 
-        const uint8 signal_id = signal_cal::get_signal_id(signal_idx);
-
         uint8 cmd = signal_rte::get_cmd(signal_cal::get_input_cmd(signal_idx));
 
         // switch on RED if a valid command hasn't been received since system start.
@@ -52,7 +50,7 @@ namespace signal
             cmd = 0; // 0 means RED by default
         }
 
-        signal_cal::get_signal_aspect(signal_id, cmd, signal_asp);
+        signal_cal::get_signal_aspect_for_idx(signal_idx, cmd, signal_asp);
 
         if (signal_asp.change_over_time_10ms == 0)
         {

--- a/Src/Prj/App/Signal/Signal.h
+++ b/Src/Prj/App/Signal/Signal.h
@@ -117,8 +117,6 @@ namespace signal
      * @defgroup RTE server runables
      * @{
      */
-    void eto_set_signal_aspect(uint8 signal_idx, uint8 aspect);
-    void eto_set_dim_time(uint8 signal_idx, uint8 dim_time_10ms);
     /** @} */
   };
 } // namespace signal

--- a/Src/Prj/App/Signal/Signal.h
+++ b/Src/Prj/App/Signal/Signal.h
@@ -74,20 +74,52 @@ namespace signal
   class SignalHandler
   {
   public:
+    /**
+     * @brief Type definition for the array of signals
+     */
     using signal_array_type = util::array<Signal, cfg::kNrSignals>;
     
   protected:
-    /// the list of cfg::kNrSignals signals
+    /**
+     * @brief The array of signals.
+     * 
+     * Each signal can be accessed via its index (0 ... cfg::kNrSignals-1).
+     */
     signal_array_type signals;
 
   public:
 
+    /**
+     * @brief Construct a new Signal Handler object
+     */
     SignalHandler()
     {}
 
-    /// RTE runables
+    /**
+     * @defgroup RTE cyclic runables
+     * @{
+     */
+    /**
+     * @brief Initialize all signals at system start
+     */
     void init();
+    /**
+     * @brief Cyclic function to be called every cycle, e.g., every 10 ms
+     * 
+     * This function reads the RTE input commands, applies them to the signals,
+     * and writes the resulting signal aspects to the RTE outputs.
+     * The signal aspects include the target intensity and dimming speed.
+     */
     void cycle();
+    /** @} */
+
+    /**
+     * @defgroup RTE server runables
+     * @{
+     */
+    void eto_set_signal_aspect(uint8 signal_idx, uint8 aspect);
+    void eto_set_dim_time(uint8 signal_idx, uint8 dim_time_10ms);
+    /** @} */
   };
 } // namespace signal
 

--- a/Src/Prj/App/Signal/Signal_cfg.h
+++ b/Src/Prj/App/Signal/Signal_cfg.h
@@ -46,15 +46,20 @@ namespace signal_cal
         return rte::get_cv(cal::cv::kSignalIDBase + signal_idx);
     }
 
-    /** @brief Get the signal aspect for a user-defined signal ID
+    /** 
+     * @brief Get the signal aspect for the signal
      * 
-     * @param signal_id Signal id (user-defined)
+     * @note The function name differs from CalM::get_signal_aspect to avoid confusion.
+     * CalM::get_signal_aspect uses the Signal ID signal_id as first parameter, this function 
+     * uses signal_idx.
+     * 
+     * @param signal_idx Signal index (0 ... cfg::kNrSignals-1)
      * @param cmd Command index (0 ... cfg::kNrSignalAspects-1)
      * @param aspect Output: signal aspect configuration
      */
-    inline void get_signal_aspect(uint8 signal_id, uint8 cmd, struct signal::signal_aspect &aspect)
+    inline void get_signal_aspect_for_idx(uint8 signal_idx, uint8 cmd, struct signal::signal_aspect &aspect)
     {
-       rte::sig::get_signal_aspect(signal_id, cmd, aspect);
+       rte::sig::get_signal_aspect_for_idx(signal_idx, cmd, aspect);
     }
     /**
      * @brief Get the input configuration for the signal


### PR DESCRIPTION
This pull request introduces support for "external take-over" (ETO) of signal aspects, allowing external systems to override signal states and dim times. The changes add new data structures, APIs, and a communication command to manage ETO functionality, update the documentation, and refactor related code for clarity.

**External Take-Over (ETO) Functionality**

* Added `eto_signal_aspect` struct and `eto_signal_aspect_array` to `CalM` for storing ETO state, aspect, and dimming time per signal.
* Implemented `get_signal_aspect_for_idx` and `eto_set_signal_aspect_for_idx` methods in `CalM` to get/set ETO aspects and dim times, overriding normal aspects when ETO is active. [[1]](diffhunk://#diff-807374416f66554aef980787f85b771982975b18979feb7523a4568988be85dbR308-R332) [[2]](diffhunk://#diff-807374416f66554aef980787f85b771982975b18979feb7523a4568988be85dbR422-R440)
* Exposed new ETO methods in the RTE API (`Rte_Cfg_Cod.h`) for getting and setting ETO signal aspects by index. [[1]](diffhunk://#diff-5c692fabe678afd9a621803121478cd735834e6209a3f2c9e6b2024f2581549eR86-R104) [[2]](diffhunk://#diff-5c692fabe678afd9a621803121478cd735834e6209a3f2c9e6b2024f2581549eR165-R181)
* Updated `Signal.cpp` to use the new ETO-aware `get_signal_aspect_for_idx` function, ensuring ETO overrides are respected during signal processing. [[1]](diffhunk://#diff-4c66e5eb0f3436721a0f4c3a16c72629c966b6dd41a88ae71e1f7c56c2df850fL45-L46) [[2]](diffhunk://#diff-4c66e5eb0f3436721a0f4c3a16c72629c966b6dd41a88ae71e1f7c56c2df850fL55-R53)

**Communication Protocol Enhancements**

* Added the `ETO_SET_SIGNAL` command to the ASCII communication interface, enabling external control of signal aspects and dim times. [[1]](diffhunk://#diff-17ccc05173c0a4cd3d358b60b7254b883e903dbee56285976f4601e0dbbd30a0R103) [[2]](diffhunk://#diff-17ccc05173c0a4cd3d358b60b7254b883e903dbee56285976f4601e0dbbd30a0L129-R130) [[3]](diffhunk://#diff-17ccc05173c0a4cd3d358b60b7254b883e903dbee56285976f4601e0dbbd30a0L139-R141) [[4]](diffhunk://#diff-17ccc05173c0a4cd3d358b60b7254b883e903dbee56285976f4601e0dbbd30a0L874-R943)
* Updated documentation in `Readme.md` to describe the new `ETO_SET_SIGNAL` command, usage examples, and expanded built-in signal descriptions. [[1]](diffhunk://#diff-d31006327da402cb8fff3deba255e3f695227217189ecf0193c03775b51925b9R104-R129) [[2]](diffhunk://#diff-d31006327da402cb8fff3deba255e3f695227217189ecf0193c03775b51925b9L84-R84)

**Documentation and Code Clarity**

* Improved comments and documentation for new and existing APIs, clarifying the distinction between signal ID and signal index usage. [[1]](diffhunk://#diff-37d883e868beefadf5156ba915267dd905f577511c3c4a2e0daa459a453f76f7L49-R62) [[2]](diffhunk://#diff-5c692fabe678afd9a621803121478cd735834e6209a3f2c9e6b2024f2581549eL74-R77) [[3]](diffhunk://#diff-d31006327da402cb8fff3deba255e3f695227217189ecf0193c03775b51925b9L139-R165)

These changes collectively enable robust external control over signal aspects, improve the communication interface, and enhance documentation for future maintenance.